### PR TITLE
Adds check for PSS option around PSS warning

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -173,21 +173,23 @@ get_options(int *argc, char **argv[]) {
 	exit(EXIT_FAILURE);
     }
 
-    /* do we support rapid PSS information (kernel 4.18+) */
-    char *fname;
-    int res;
-    FILE *f;
-    pid_t pid = getpid();
-    if ((res = asprintf(&fname, "/proc/%ld/smaps_rollup", (long)pid)) == -1) {
-        error(EXIT_FAILURE, 0, "failed to create file name string.\n");
-    }
+    if (opts->pss == true) {
+        /* do we support rapid PSS information (kernel 4.18+) */
+        char *fname;
+        int res;
+        FILE *f;
+        pid_t pid = getpid();
+        if ((res = asprintf(&fname, "/proc/%ld/smaps_rollup", (long)pid)) == -1) {
+            error(EXIT_FAILURE, 0, "failed to create file name string.\n");
+        }
 
-    if ((f = fopen(fname, "r"))==NULL) {
-        error(0, 0, "\n** Warning **\n\
-/proc/*/smaps_rollup not supported on this system.\n\
-Rapid PSS estimation not possible. Falling back on RSS.\n\
-To remove this message, use \"--rss\" or rebuild without PSS.\n\n");
-        opts->pss = false;
+        if ((f = fopen(fname, "r"))==NULL) {
+            error(0, 0, "\n** Warning **\n\
+    /proc/*/smaps_rollup not supported on this system.\n\
+    Rapid PSS estimation not possible. Falling back on RSS.\n\
+    To remove this message, use \"--rss\" or rebuild without PSS.\n\n");
+            opts->pss = false;
+        }
     }
 
     // point argv and argc to profiled program forwards


### PR DESCRIPTION
Currently, the check for whether PSS reading is available is always run, even if we don't want to use it.

This change checks whether it was requested before checking.

Arguably it might also be desirable to check whether it was requested or just the default, and fail if it was specifically requested, but that's a larger change.

This is a suggested fix for #6.